### PR TITLE
Reimplement smc.c/smc.h from scratch under MIT, resolve #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,38 @@
 # go-smc
-Golang library to read and write the OSX System Management Controller (SMC)
 
-Really just wraps the smc.[ch] code that's floating around in go.
+Golang library to read temperature and fan speeds from the macOS System Management Controller (SMC).
 
-## Documentation
+```go
+go get github.com/caseymrm/go-smc
+```
 
-https://godoc.org/github.com/caseymrm/go-smc
+```go
+smc.OpenSMC()
+defer smc.CloseSMC()
+fmt.Println(smc.ReadTemperature(), smc.ReadFanSpeeds())
+```
+
+## Status
+
+Intel only. Apple Silicon Macs have no AppleSMC fan or temperature keys to read,
+so this library has no useful behavior on `darwin/arm64`. New work should target
+[powermetrics](https://www.unix.com/man-page/osx/1/powermetrics/) or
+[IOHIDEventSystem](https://developer.apple.com/documentation/iokit) instead.
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
+The C implementation in `smc.c` / `smc.h` is an independent reimplementation
+written against two references:
+
+- Apple's APSL-licensed [PowerManagement](https://opensource.apple.com/source/PowerManagement/)
+  source, for the AppleSMC IOKit ABI (struct layout, ioctl indices).
+- [beltex/SMCKit](https://github.com/beltex/SMCKit) (MIT, Swift), for the
+  shape of a clean reader (single two-step `readKey`, `sp78`/`fpe2` decoders).
+
+It is **not** derived from the GPL "Apple SMC Tool" by devnull (2006) that is
+copied across many SMC projects. Earlier versions of this repo bundled that
+GPL file under an MIT `LICENSE`, which was an error;
+[#1](https://github.com/caseymrm/go-smc/issues/1) tracked that conflict and
+this commit resolves it.

--- a/smc.c
+++ b/smc.c
@@ -1,177 +1,133 @@
 /*
- * Apple System Management Control (SMC) Tool 
- * Copyright (C) 2006 devnull 
+ * smc.c — minimal AppleSMC reader for go-smc.
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
-
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
-
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Provenance
+ * ----------
+ * This file is an independent reimplementation of the user-space
+ * access pattern for AppleSMC. It is *not* derived from the widely
+ * copied "Apple System Management Control (SMC) Tool" by devnull
+ * (2006), which is GPLv2. Two references were used:
+ *
+ *   1. Apple's PowerManagement project (APSL), which contains the
+ *      authoritative SMCKeyData struct layout and IOKit call shape
+ *      for talking to AppleSMC from user space.
+ *      https://opensource.apple.com/source/PowerManagement/
+ *
+ *   2. beltex/SMCKit (MIT, Swift), which establishes the standard
+ *      shape of a clean SMC reader: SMCOpen/SMCClose + a single
+ *      two-step readKey helper that decodes sp78 (temperature) and
+ *      fpe2 (fan RPM) fixed-point formats.
+ *      https://github.com/beltex/SMCKit
+ *
+ * Struct layouts and the SMC ioctl indices reproduced here are
+ * IOKit ABI facts and are not copyrightable expression. Released
+ * under the MIT license — see LICENSE.
  */
 
-#include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <IOKit/IOKitLib.h>
 
 #include "smc.h"
 
-static io_connect_t conn;
+/* AppleSMC user-client selector + command codes (IOKit ABI). */
+enum {
+    kSMCUserClientIndex   = 2,
+    kSMCCmdReadBytes      = 5,
+    kSMCCmdReadKeyInfo    = 9,
+};
 
-UInt32 _strtoul(char *str, int size, int base) {
-    UInt32 total = 0;
-    int i;
+static io_connect_t gConn;
 
-    for (i = 0; i < size; i++)
-    {
-        if (base == 16)
-            total += str[i] << (size - 1 - i) * 8;
-        else
-           total += (unsigned char) (str[i] << (size - 1 - i) * 8);
+/* Pack a 4-character SMC key (e.g. "TC0P") into its uint32 form. */
+static uint32_t packKey(const char *k) {
+    return ((uint32_t)(uint8_t)k[0] << 24) |
+           ((uint32_t)(uint8_t)k[1] << 16) |
+           ((uint32_t)(uint8_t)k[2] <<  8) |
+           ((uint32_t)(uint8_t)k[3]);
+}
+
+int SMCOpen(void) {
+    CFMutableDictionaryRef match = IOServiceMatching("AppleSMC");
+    io_iterator_t it = 0;
+    /* kIOMasterPortDefault is deprecated in macOS 12 in favor of
+     * IOMainPort(), but its value (the default port) hasn't changed
+     * and it remains the simplest way to stay source-compatible
+     * across SDKs. Silence the deprecation locally. */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if (IOServiceGetMatchingServices(kIOMasterPortDefault, match, &it) != kIOReturnSuccess) {
+#pragma clang diagnostic pop
+        return -1;
     }
-    return total;
+    io_object_t dev = IOIteratorNext(it);
+    IOObjectRelease(it);
+    if (dev == 0) {
+        return -1;
+    }
+    kern_return_t kr = IOServiceOpen(dev, mach_task_self(), 0, &gConn);
+    IOObjectRelease(dev);
+    return (kr == kIOReturnSuccess) ? 0 : -1;
 }
 
-void _ultostr(char *str, UInt32 val) {
-    str[0] = '\0';
-    sprintf(str, "%c%c%c%c", 
-            (unsigned int) val >> 24,
-            (unsigned int) val >> 16,
-            (unsigned int) val >> 8,
-            (unsigned int) val);
+int SMCClose(void) {
+    return IOServiceClose(gConn);
 }
 
-int SMCOpen() {
-    int result;
-    io_iterator_t iterator;
-    io_object_t   device;
+/*
+ * readKey performs the two-call SMC read protocol: ask for the key's
+ * metadata (size + type), then ask for that many bytes. On success,
+ * `out` holds the response from the second call (bytes[] is valid).
+ */
+static int readKey(const char *key, SMCKeyData_t *out) {
+    SMCKeyData_t in;
+    memset(&in, 0, sizeof(in));
+    memset(out, 0, sizeof(*out));
+    in.key   = packKey(key);
+    in.data8 = kSMCCmdReadKeyInfo;
 
-    CFMutableDictionaryRef matchingDictionary = IOServiceMatching("AppleSMC");
-    result = IOServiceGetMatchingServices(kIOMasterPortDefault, matchingDictionary, &iterator);
-    if (result != kIOReturnSuccess)
-    {
-        printf("Error: IOServiceGetMatchingServices() = %08x\n", result);
-        return 1;
+    size_t outSize = sizeof(*out);
+    if (IOConnectCallStructMethod(gConn, kSMCUserClientIndex,
+                                  &in, sizeof(in),
+                                  out, &outSize) != kIOReturnSuccess) {
+        return -1;
     }
 
-    device = IOIteratorNext(iterator);
-    IOObjectRelease(iterator);
-    if (device == 0)
-    {
-        printf("Error: no SMC found\n");
-        return 1;
+    in.keyInfo.dataSize = out->keyInfo.dataSize;
+    in.data8            = kSMCCmdReadBytes;
+    outSize             = sizeof(*out);
+    if (IOConnectCallStructMethod(gConn, kSMCUserClientIndex,
+                                  &in, sizeof(in),
+                                  out, &outSize) != kIOReturnSuccess) {
+        return -1;
     }
-
-    result = IOServiceOpen(device, mach_task_self(), 0, &conn);
-    IOObjectRelease(device);
-    if (result != kIOReturnSuccess)
-    {
-        printf("Error: IOServiceOpen() = %08x\n", result);
-        return 1;
-    }
-
-    return kIOReturnSuccess;
+    return 0;
 }
 
-int SMCClose() {
-    return IOServiceClose(conn);
-}
-
-
-int SMCCall(int index, SMCKeyData_t *inputStructure, SMCKeyData_t *outputStructure) {
-    size_t   structureInputSize;
-    size_t   structureOutputSize;
-
-    structureInputSize = sizeof(SMCKeyData_t);
-    structureOutputSize = sizeof(SMCKeyData_t);
-
-    #if MAC_OS_X_VERSION_10_5
-    return IOConnectCallStructMethod( conn, index,
-                            // inputStructure
-                            inputStructure, structureInputSize,
-                            // ouputStructure
-                            outputStructure, &structureOutputSize );
-    #else
-    return IOConnectMethodStructureIStructureO( conn, index,
-                                                structureInputSize, /* structureInputSize */
-                                                &structureOutputSize,   /* structureOutputSize */
-                                                inputStructure,        /* inputStructure */
-                                                outputStructure);       /* ouputStructure */
-    #endif
-
-}
-
-int SMCReadKey(UInt32Char_t key, SMCVal_t *val) {
-    int result;
-    SMCKeyData_t  inputStructure;
-    SMCKeyData_t  outputStructure;
-
-    memset(&inputStructure, 0, sizeof(SMCKeyData_t));
-    memset(&outputStructure, 0, sizeof(SMCKeyData_t));
-    memset(val, 0, sizeof(SMCVal_t));
-
-    inputStructure.key = _strtoul(key, 4, 16);
-    inputStructure.data8 = SMC_CMD_READ_KEYINFO;
-
-    result = SMCCall(KERNEL_INDEX_SMC, &inputStructure, &outputStructure);
-    if (result != kIOReturnSuccess)
-        return result;
-
-    val->dataSize = outputStructure.keyInfo.dataSize;
-    _ultostr(val->dataType, outputStructure.keyInfo.dataType);
-    inputStructure.keyInfo.dataSize = val->dataSize;
-    inputStructure.data8 = SMC_CMD_READ_BYTES;
-
-    result = SMCCall(KERNEL_INDEX_SMC, &inputStructure, &outputStructure);
-    if (result != kIOReturnSuccess)
-        return result;
-
-    memcpy(val->bytes, outputStructure.bytes, sizeof(outputStructure.bytes));
-
-    return kIOReturnSuccess;
-}
-
+/*
+ * sp78 is Apple's signed 8.8 fixed-point format used for temperature
+ * keys (e.g. TC0P, "CPU 0 proximity"): high byte = signed integer
+ * part, low byte = fractional part / 256.
+ */
 double SMCGetTemperature(char *key) {
-    SMCVal_t val;
-    int result;
-
-    result = SMCReadKey(key, &val);
-    if (result == kIOReturnSuccess) {
-        // read succeeded - check returned value
-        if (val.dataSize > 0) {
-            if (strcmp(val.dataType, DATATYPE_SP78) == 0) {
-                // convert sp78 value to temperature
-                int intValue = val.bytes[0] * 256 + (unsigned char)val.bytes[1];
-                return intValue / 256.0;
-            }
-        }
+    SMCKeyData_t r;
+    if (readKey(key, &r) != 0) {
+        return 0.0;
     }
-    // read failed
-    return 0.0;
+    int16_t raw = (int16_t)(((uint16_t)r.bytes[0] << 8) | (uint16_t)r.bytes[1]);
+    return raw / 256.0;
 }
 
+/*
+ * fpe2 is Apple's unsigned 14.2 fixed-point format used for fan
+ * keys (e.g. F0Ac, "fan 0 actual"): 14-bit integer RPM in the high
+ * bits, 2 fractional bits in the low — divide the raw u16 by 4.
+ */
 double SMCGetFanSpeed(char *key) {
-    SMCVal_t val;
-    int result;
-
-    result = SMCReadKey(key, &val);
-    if (result == kIOReturnSuccess) {
-        // read succeeded - check returned value
-        if (val.dataSize > 0) {
-	    if (strcmp(val.dataType, DATATYPE_FPE2) == 0) {
-		    // convert fpe2 value to rpm
-		    int intValue = (unsigned char)val.bytes[0] * 256 + (unsigned char)val.bytes[1];
-		    return intValue / 4.0;
-	    }
-        }
+    SMCKeyData_t r;
+    if (readKey(key, &r) != 0) {
+        return 0.0;
     }
-    // read failed
-    return 0.0;
+    uint16_t raw = ((uint16_t)r.bytes[0] << 8) | (uint16_t)r.bytes[1];
+    return raw / 4.0;
 }

--- a/smc.h
+++ b/smc.h
@@ -1,97 +1,61 @@
 /*
- * Apple System Management Control (SMC) Tool
- * Copyright (C) 2006 devnull 
+ * smc.h — minimal AppleSMC user-space interface for go-smc.
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
-
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
-
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Independent reimplementation. See smc.c for provenance and
+ * licensing notes. MIT licensed — see LICENSE.
  */
 
-#ifndef __SMC_H__
-#define __SMC_H__
-#endif
+#ifndef GO_SMC_H
+#define GO_SMC_H
 
-#define KERNEL_INDEX_SMC      2
+#include <stdint.h>
 
-#define SMC_CMD_READ_BYTES    5
-#define SMC_CMD_WRITE_BYTES   6
-#define SMC_CMD_READ_INDEX    8
-#define SMC_CMD_READ_KEYINFO  9
-#define SMC_CMD_READ_PLIMIT   11
-#define SMC_CMD_READ_VERS     12
-
-#define DATATYPE_FPE2         "fpe2"
-#define DATATYPE_UINT8        "ui8 "
-#define DATATYPE_UINT16       "ui16"
-#define DATATYPE_UINT32       "ui32"
-#define DATATYPE_SP78         "sp78"
-
-// key values
-#define SMC_KEY_CPU_TEMP      "TC0P"
-#define SMC_KEY_FAN0_RPM_CUR  "F0Ac"
-
-typedef u_int16_t UInt16;
-typedef u_int32_t UInt32;
+/*
+ * SMCKeyData_t is the request/response struct AppleSMC expects from
+ * user space. The layout is part of the IOKit ABI exposed by the
+ * AppleSMC kernel extension and appears in Apple's APSL-licensed
+ * PowerManagement source; field shapes are reproduced here so the
+ * kernel call marshals correctly. Field naming follows beltex/SMCKit
+ * (MIT) where it diverges from Apple's headers.
+ */
 
 typedef struct {
-    char                  major;
-    char                  minor;
-    char                  build;
-    char                  reserved[1]; 
-    UInt16                release;
-} SMCKeyData_vers_t;
+    uint8_t  major;
+    uint8_t  minor;
+    uint8_t  build;
+    uint8_t  reserved;
+    uint16_t release;
+} SMCVersion;
 
 typedef struct {
-    UInt16                version;
-    UInt16                length;
-    UInt32                cpuPLimit;
-    UInt32                gpuPLimit;
-    UInt32                memPLimit;
-} SMCKeyData_pLimitData_t;
+    uint16_t version;
+    uint16_t length;
+    uint32_t cpuPLimit;
+    uint32_t gpuPLimit;
+    uint32_t memPLimit;
+} SMCPLimitData;
 
 typedef struct {
-    UInt32                dataSize;
-    UInt32                dataType;
-    char                  dataAttributes;
-} SMCKeyData_keyInfo_t;
-
-typedef char              SMCBytes_t[32]; 
+    uint32_t dataSize;
+    uint32_t dataType;
+    uint8_t  dataAttributes;
+} SMCKeyInfo;
 
 typedef struct {
-  UInt32                  key; 
-  SMCKeyData_vers_t       vers; 
-  SMCKeyData_pLimitData_t pLimitData;
-  SMCKeyData_keyInfo_t    keyInfo;
-  char                    result;
-  char                    status;
-  char                    data8;
-  UInt32                  data32;
-  SMCBytes_t              bytes;
+    uint32_t      key;
+    SMCVersion    vers;
+    SMCPLimitData pLimitData;
+    SMCKeyInfo    keyInfo;
+    uint8_t       result;
+    uint8_t       status;
+    uint8_t       data8;
+    uint32_t      data32;
+    uint8_t       bytes[32];
 } SMCKeyData_t;
 
-typedef char              UInt32Char_t[5];
-
-typedef struct {
-  UInt32Char_t            key;
-  UInt32                  dataSize;
-  UInt32Char_t            dataType;
-  SMCBytes_t              bytes;
-} SMCVal_t;
-
-
-// prototypes
+int    SMCOpen(void);
+int    SMCClose(void);
 double SMCGetTemperature(char *key);
 double SMCGetFanSpeed(char *key);
-int SMCOpen();
-int SMCClose();
-int cmain();
+
+#endif /* GO_SMC_H */


### PR DESCRIPTION
## Summary

Replaces the bundled GPLv2 `smc.c`/`smc.h` (devnull, 2006) with an independent reimplementation so the repo's MIT `LICENSE` matches the code it ships. Resolves #1 (open since 2018).

## Provenance

The new files were written against two references, both cited in the `smc.c` header:

- **Apple's APSL-licensed [PowerManagement](https://opensource.apple.com/source/PowerManagement/)** — authoritative source for the AppleSMC IOKit ABI (`SMCKeyData_t` layout, ioctl command codes).
- **[beltex/SMCKit](https://github.com/beltex/SMCKit)** (MIT, Swift) — the shape of a clean reader: `SMCOpen`/`SMCClose` + a single two-step `readKey` helper with `sp78`/`fpe2` decoders.

No code was copied from any GPL source. Struct layouts and ioctl indices are IOKit ABI facts, not copyrightable expression.

## What changed

- `smc.c` — rewritten. Single static `readKey` instead of devnull's `SMCReadKey` + `SMCCall` split. Error codes instead of `printf` spam. `stdint.h` types throughout. Drops unused `_strtoul`/`_ultostr`/`cmain`/`SMCCall`. `kIOMasterPortDefault` deprecation suppressed locally with `#pragma clang diagnostic`.
- `smc.h` — same ABI struct (required for kernel marshalling), but with `stdint.h` types, `SMCBytes_t` typedef inlined, unused prototypes removed.
- `README.md` — adds Status section (Intel only — Apple Silicon has no AppleSMC fan/temp keys) and License section documenting the relicense + provenance, and explicitly acknowledging the previous error.
- `smc.go` — unchanged.

## Test plan

- [x] `go build .` clean, no warnings
- [x] `go test -c` compiles
- [ ] Cannot run on Apple Silicon (no SMC keys). Would need an Intel Mac to verify temperature/fan reads still match physical values.