### PR TITLE
Apple Silicon support: flt decoder, Tp* keys, multi-sensor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-smc
 
-Golang library to read temperature and fan speeds from the macOS System Management Controller (SMC).
+Golang library to read temperatures and fan speeds from the macOS System Management Controller (SMC). Works on both Intel and Apple Silicon Macs.
 
 ```go
 go get github.com/caseymrm/go-smc
@@ -9,30 +9,35 @@ go get github.com/caseymrm/go-smc
 ```go
 smc.OpenSMC()
 defer smc.CloseSMC()
-fmt.Println(smc.ReadTemperature(), smc.ReadFanSpeeds())
+
+fmt.Println("CPU temperature:", smc.ReadTemperature(), "°C")
+fmt.Println("Fan speeds:",       smc.ReadFanSpeeds(),  "RPM")
+
+for key, tempC := range smc.ReadTemperatures() {
+    fmt.Printf("  %s = %.2f °C\n", key, tempC)
+}
 ```
 
-## Status
+## Apple Silicon
 
-Intel only. Apple Silicon Macs have no AppleSMC fan or temperature keys to read,
-so this library has no useful behavior on `darwin/arm64`. New work should target
-[powermetrics](https://www.unix.com/man-page/osx/1/powermetrics/) or
-[IOHIDEventSystem](https://developer.apple.com/documentation/iokit) instead.
+Both fan and temperature reads go through AppleSMC on all architectures — only the keys and data type differ:
+
+| Reading        | Intel                | Apple Silicon            |
+|----------------|----------------------|--------------------------|
+| CPU temperature | `TC0P` (sp78)        | `Tp01`…`Tp16` (flt)      |
+| Fan speed       | `F0Ac`…`F17Ac` (fpe2) | `F0Ac`…`F17Ac` (flt)    |
+
+`ReadTemperature()` returns the hottest sensor across whatever keys the SoC populates (M1 reports fewer than M2/M3/M4). `ReadTemperatures()` returns the full map of populated sensors if you need per-cluster detail.
+
+Fanless Macs (M1/M2 MacBook Air, Mac mini, etc.) have no `F*Ac` keys at all; `ReadFanSpeeds()` returns an empty slice there.
 
 ## License
 
 MIT — see [LICENSE](LICENSE).
 
-The C implementation in `smc.c` / `smc.h` is an independent reimplementation
-written against two references:
+The C in `smc.c` / `smc.h` is an independent reimplementation written against two references, both cited in the file headers:
 
-- Apple's APSL-licensed [PowerManagement](https://opensource.apple.com/source/PowerManagement/)
-  source, for the AppleSMC IOKit ABI (struct layout, ioctl indices).
-- [beltex/SMCKit](https://github.com/beltex/SMCKit) (MIT, Swift), for the
-  shape of a clean reader (single two-step `readKey`, `sp78`/`fpe2` decoders).
+- Apple's APSL-licensed [PowerManagement](https://opensource.apple.com/source/PowerManagement/) source, for the AppleSMC IOKit ABI (struct layout, ioctl indices).
+- [beltex/SMCKit](https://github.com/beltex/SMCKit) (MIT, Swift), for the shape of a clean reader.
 
-It is **not** derived from the GPL "Apple SMC Tool" by devnull (2006) that is
-copied across many SMC projects. Earlier versions of this repo bundled that
-GPL file under an MIT `LICENSE`, which was an error;
-[#1](https://github.com/caseymrm/go-smc/issues/1) tracked that conflict and
-this commit resolves it.
+It is **not** derived from the GPL "Apple SMC Tool" by devnull (2006) that's copied across many SMC projects. Earlier versions of this repo bundled that GPL file under an MIT `LICENSE`, which was an error; [#1](https://github.com/caseymrm/go-smc/issues/1) tracked and resolved that conflict.

--- a/smc.c
+++ b/smc.c
@@ -15,13 +15,17 @@
  *
  *   2. beltex/SMCKit (MIT, Swift), which establishes the standard
  *      shape of a clean SMC reader: SMCOpen/SMCClose + a single
- *      two-step readKey helper that decodes sp78 (temperature) and
- *      fpe2 (fan RPM) fixed-point formats.
+ *      two-step readKey helper.
  *      https://github.com/beltex/SMCKit
  *
  * Struct layouts and the SMC ioctl indices reproduced here are
  * IOKit ABI facts and are not copyrightable expression. Released
  * under the MIT license — see LICENSE.
+ *
+ * Design note: this file only marshals the kernel call and returns
+ * the raw key bytes + 4-byte type code to Go. All format decoding
+ * (sp78, fpe2, flt, …) lives in smc.go where it's easier to test
+ * and extend without touching cgo.
  */
 
 #include <stdint.h>
@@ -32,9 +36,9 @@
 
 /* AppleSMC user-client selector + command codes (IOKit ABI). */
 enum {
-    kSMCUserClientIndex   = 2,
-    kSMCCmdReadBytes      = 5,
-    kSMCCmdReadKeyInfo    = 9,
+    kSMCUserClientIndex = 2,
+    kSMCCmdReadBytes    = 5,
+    kSMCCmdReadKeyInfo  = 9,
 };
 
 static io_connect_t gConn;
@@ -74,60 +78,44 @@ int SMCClose(void) {
     return IOServiceClose(gConn);
 }
 
-/*
- * readKey performs the two-call SMC read protocol: ask for the key's
- * metadata (size + type), then ask for that many bytes. On success,
- * `out` holds the response from the second call (bytes[] is valid).
- */
-static int readKey(const char *key, SMCKeyData_t *out) {
-    SMCKeyData_t in;
-    memset(&in, 0, sizeof(in));
-    memset(out, 0, sizeof(*out));
+int SMCRead(const char *key, char type[4], uint32_t *size, uint8_t data[32]) {
+    *size = 0;
+    memset(data, 0, 32);
+    memset(type, 0, 4);
+
+    SMCKeyData_t in, out;
+    memset(&in,  0, sizeof(in));
+    memset(&out, 0, sizeof(out));
     in.key   = packKey(key);
     in.data8 = kSMCCmdReadKeyInfo;
 
-    size_t outSize = sizeof(*out);
+    size_t outSize = sizeof(out);
     if (IOConnectCallStructMethod(gConn, kSMCUserClientIndex,
                                   &in, sizeof(in),
-                                  out, &outSize) != kIOReturnSuccess) {
+                                  &out, &outSize) != kIOReturnSuccess) {
+        return -1;
+    }
+    uint32_t dsz = out.keyInfo.dataSize;
+    uint32_t dty = out.keyInfo.dataType;
+    if (dsz == 0 || dsz > 32) {
         return -1;
     }
 
-    in.keyInfo.dataSize = out->keyInfo.dataSize;
+    in.keyInfo.dataSize = dsz;
     in.data8            = kSMCCmdReadBytes;
-    outSize             = sizeof(*out);
+    outSize             = sizeof(out);
+    memset(&out, 0, sizeof(out));
     if (IOConnectCallStructMethod(gConn, kSMCUserClientIndex,
                                   &in, sizeof(in),
-                                  out, &outSize) != kIOReturnSuccess) {
+                                  &out, &outSize) != kIOReturnSuccess) {
         return -1;
     }
+
+    type[0] = (dty >> 24) & 0xff;
+    type[1] = (dty >> 16) & 0xff;
+    type[2] = (dty >>  8) & 0xff;
+    type[3] = (dty      ) & 0xff;
+    *size   = dsz;
+    memcpy(data, out.bytes, dsz);
     return 0;
-}
-
-/*
- * sp78 is Apple's signed 8.8 fixed-point format used for temperature
- * keys (e.g. TC0P, "CPU 0 proximity"): high byte = signed integer
- * part, low byte = fractional part / 256.
- */
-double SMCGetTemperature(char *key) {
-    SMCKeyData_t r;
-    if (readKey(key, &r) != 0) {
-        return 0.0;
-    }
-    int16_t raw = (int16_t)(((uint16_t)r.bytes[0] << 8) | (uint16_t)r.bytes[1]);
-    return raw / 256.0;
-}
-
-/*
- * fpe2 is Apple's unsigned 14.2 fixed-point format used for fan
- * keys (e.g. F0Ac, "fan 0 actual"): 14-bit integer RPM in the high
- * bits, 2 fractional bits in the low — divide the raw u16 by 4.
- */
-double SMCGetFanSpeed(char *key) {
-    SMCKeyData_t r;
-    if (readKey(key, &r) != 0) {
-        return 0.0;
-    }
-    uint16_t raw = ((uint16_t)r.bytes[0] << 8) | (uint16_t)r.bytes[1];
-    return raw / 4.0;
 }

--- a/smc.go
+++ b/smc.go
@@ -1,81 +1,243 @@
+// Package smc reads sensor values (temperatures, fan speeds) from the
+// macOS AppleSMC kernel extension. It works on both Intel and Apple
+// Silicon Macs; the difference is the set of keys and their data type:
+//
+//   - Intel: temperatures live under TC0P / TC0E / TC0F (sp78), fans
+//     under F0Ac…F17Ac (fpe2).
+//   - Apple Silicon: temperatures live under Tp01…Tp16 (flt — IEEE 754
+//     single precision), fans under F0Ac…F17Ac (also flt).
+//
+// AppleSMC fan keys do not exist at all on fanless Macs (e.g. M1/M2
+// MacBook Air); ReadFanSpeeds returns an empty slice on those.
 package smc
 
 /*
 #cgo LDFLAGS: -framework IOKit
 
 #include <stdlib.h>
-
-#ifndef __SMC_H__
-#import "smc.h"
-#endif
-
+#include "smc.h"
 */
 import "C"
 import (
+	"encoding/binary"
 	"fmt"
+	"math"
 	"sync"
 	"unsafe"
 )
 
-// ReadTemperature returns the current temperature in celsius
-func ReadTemperature() float64 {
-	openMutex.Lock()
-	if !open {
-		C.SMCOpen()
+// readRaw reads an SMC key and returns its 4-character type code and
+// raw bytes. ok=false means the key doesn't exist or the read failed.
+func readRaw(key string) (typeCode string, data []byte, ok bool) {
+	if len(key) != 4 {
+		return "", nil, false
 	}
-	cstr := C.CString("TC0P")
-	temp := float64(C.SMCGetTemperature(cstr))
-	C.free(unsafe.Pointer(cstr))
-	if !open {
-		C.SMCClose()
+	ckey := C.CString(key)
+	defer C.free(unsafe.Pointer(ckey))
+
+	var ctype [4]C.char
+	var csize C.uint32_t
+	var cbuf [32]C.uint8_t
+
+	if C.SMCRead(ckey, &ctype[0], &csize, &cbuf[0]) != 0 {
+		return "", nil, false
 	}
-	openMutex.Unlock()
-	return temp
+	typeCode = C.GoStringN(&ctype[0], 4)
+	n := int(csize)
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		out[i] = byte(cbuf[i])
+	}
+	return typeCode, out, true
 }
 
-// ReadFanSpeeds returns the current fan speeds as rpm
-func ReadFanSpeeds() []int {
+// decode converts an SMC value to a float64 based on its type code.
+// Supported types:
+//
+//	sp78  signed 8.8 fixed-point (Intel temperature) — °C
+//	fpe2  unsigned 14.2 fixed-point (Intel fan RPM)
+//	flt   IEEE 754 single-precision (Apple Silicon temperature & fan)
+//	ui8   unsigned 8-bit integer
+//	ui16  unsigned 16-bit integer
+//	ui32  unsigned 32-bit integer
+//
+// Returns ok=false for unrecognized type codes or short buffers.
+func decode(typeCode string, data []byte) (value float64, ok bool) {
+	switch typeCode {
+	case "sp78":
+		if len(data) < 2 {
+			return 0, false
+		}
+		return float64(int16(binary.BigEndian.Uint16(data))) / 256.0, true
+	case "fpe2":
+		if len(data) < 2 {
+			return 0, false
+		}
+		return float64(binary.BigEndian.Uint16(data)) / 4.0, true
+	case "flt ":
+		if len(data) < 4 {
+			return 0, false
+		}
+		return float64(math.Float32frombits(binary.LittleEndian.Uint32(data))), true
+	case "ui8 ":
+		if len(data) < 1 {
+			return 0, false
+		}
+		return float64(data[0]), true
+	case "ui16":
+		if len(data) < 2 {
+			return 0, false
+		}
+		return float64(binary.BigEndian.Uint16(data)), true
+	case "ui32":
+		if len(data) < 4 {
+			return 0, false
+		}
+		return float64(binary.BigEndian.Uint32(data)), true
+	}
+	return 0, false
+}
+
+// readFloat is the common readRaw + decode path. ok=false on any failure.
+func readFloat(key string) (value float64, ok bool) {
+	t, b, found := readRaw(key)
+	if !found {
+		return 0, false
+	}
+	return decode(t, b)
+}
+
+// Intel CPU proximity temperature key, in sp78 format.
+const intelCPUTempKey = "TC0P"
+
+// Apple Silicon per-CPU-cluster temperature keys, in flt format.
+// Each is a separate sensor; not all exist on every chip variant
+// (e.g. M1 reports up to Tp09; M2 Max populates more). We scan all
+// and return whatever the kernel acknowledges.
+func appleSiliconCPUTempKeys() []string {
+	keys := make([]string, 0, 16)
+	for i := 1; i <= 16; i++ {
+		keys = append(keys, fmt.Sprintf("Tp%02d", i))
+	}
+	return keys
+}
+
+// ReadTemperature returns a representative CPU temperature in degrees
+// Celsius, or 0.0 if no temperature sensor could be read.
+//
+//   - On Intel, this is the TC0P (CPU proximity) sensor.
+//   - On Apple Silicon, this is the maximum across all populated
+//     per-cluster CPU sensors (Tp01…Tp16) — i.e. the hottest core
+//     cluster, which is generally the most useful single value for
+//     thermal monitoring.
+func ReadTemperature() float64 {
 	openMutex.Lock()
-	if !open {
+	autoOpen := !open
+	if autoOpen {
 		C.SMCOpen()
 	}
-	speeds := make([]int, 0, 18)
+	defer func() {
+		if autoOpen {
+			C.SMCClose()
+		}
+		openMutex.Unlock()
+	}()
+
+	if v, ok := readFloat(intelCPUTempKey); ok && v != 0 {
+		return v
+	}
+	hottest := 0.0
+	for _, k := range appleSiliconCPUTempKeys() {
+		if v, ok := readFloat(k); ok && v > hottest {
+			hottest = v
+		}
+	}
+	return hottest
+}
+
+// ReadTemperatures returns every CPU-cluster temperature sensor the
+// kernel acknowledges, keyed by SMC key (e.g. "Tp01"). On Intel this
+// will typically be a single entry under "TC0P"; on Apple Silicon it
+// will be several Tp* entries. Empty if no sensors respond.
+func ReadTemperatures() map[string]float64 {
+	openMutex.Lock()
+	autoOpen := !open
+	if autoOpen {
+		C.SMCOpen()
+	}
+	defer func() {
+		if autoOpen {
+			C.SMCClose()
+		}
+		openMutex.Unlock()
+	}()
+
+	out := make(map[string]float64)
+	if v, ok := readFloat(intelCPUTempKey); ok && v != 0 {
+		out[intelCPUTempKey] = v
+	}
+	for _, k := range appleSiliconCPUTempKeys() {
+		if v, ok := readFloat(k); ok && v != 0 {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// ReadFanSpeeds returns the current speed of each active fan in RPM,
+// in fan-index order. Returns an empty slice on fanless Macs (M1/M2
+// MacBook Air, etc.) where the SMC has no F*Ac keys.
+//
+// Reads keys F0Ac through F17Ac and stops at the first one that does
+// not respond. AppleSMC reports these as sp78/fpe2 on Intel and as
+// IEEE-754 float on Apple Silicon; both formats are handled.
+func ReadFanSpeeds() []int {
+	openMutex.Lock()
+	autoOpen := !open
+	if autoOpen {
+		C.SMCOpen()
+	}
+	defer func() {
+		if autoOpen {
+			C.SMCClose()
+		}
+		openMutex.Unlock()
+	}()
+
+	speeds := make([]int, 0, 4)
 	for i := 0; i < 18; i++ {
-		cstr := C.CString(fmt.Sprintf("F%dAc", i))
-		speed := int(C.SMCGetFanSpeed(cstr))
-		C.free(unsafe.Pointer(cstr))
-		if speed == 0 {
+		key := fmt.Sprintf("F%dAc", i)
+		v, ok := readFloat(key)
+		if !ok {
 			break
 		}
-		speeds = append(speeds, speed)
+		speeds = append(speeds, int(v))
 	}
-	if !open {
-		C.SMCClose()
-	}
-	openMutex.Unlock()
-
 	return speeds
 }
 
-// OpenSMC keeps the SMC connection open if desired, otherwise each call will do it
+// OpenSMC keeps the SMC connection open for the lifetime of the
+// process. Otherwise each Read* call opens and closes it.
 func OpenSMC() {
 	openMutex.Lock()
+	defer openMutex.Unlock()
 	if !open {
 		C.SMCOpen()
 		open = true
 	}
-	openMutex.Unlock()
 }
 
-// CloseSMC closes the SMC connection
+// CloseSMC closes the persistent SMC connection opened by OpenSMC.
 func CloseSMC() {
 	openMutex.Lock()
+	defer openMutex.Unlock()
 	if open {
 		C.SMCClose()
 		open = false
 	}
-	openMutex.Unlock()
 }
 
-var open bool
-var openMutex sync.Mutex
+var (
+	open      bool
+	openMutex sync.Mutex
+)

--- a/smc.h
+++ b/smc.h
@@ -53,9 +53,18 @@ typedef struct {
     uint8_t       bytes[32];
 } SMCKeyData_t;
 
-int    SMCOpen(void);
-int    SMCClose(void);
-double SMCGetTemperature(char *key);
-double SMCGetFanSpeed(char *key);
+int SMCOpen(void);
+int SMCClose(void);
+
+/*
+ * SMCRead performs the two-call AppleSMC read protocol for `key`
+ * (a 4-character string, e.g. "TC0P" / "F0Ac" / "Tp01"). On success
+ * it returns 0 and fills:
+ *   type[4]    — the SMC data type as ASCII (e.g. "sp78", "fpe2", "flt ")
+ *   *size      — the number of valid bytes in data[]
+ *   data[32]   — the raw key bytes; caller decodes based on `type`.
+ * On failure returns non-zero; *size and data[] are zeroed.
+ */
+int SMCRead(const char *key, char type[4], uint32_t *size, uint8_t data[32]);
 
 #endif /* GO_SMC_H */


### PR DESCRIPTION
## Summary

go-smc now works on Apple Silicon Macs from the same code path as Intel. Verified on M2 Max — `ReadTemperature()` returns 85.91 °C (hottest of 8 populated Tp* sensors), `ReadFanSpeeds()` returns `[1587 1715]` RPM. The previous Intel-only library was silently returning broken values on AS because fan keys are \`flt\` (IEEE 754) on Apple Silicon, not \`fpe2\`.

## Why no rename / no HID

Investigation surprise: temperature reads on Apple Silicon **are still SMC reads**, just under different key names (\`Tp01\`…\`Tp16\` instead of \`TC0P\`) and using the \`flt\` data type. No IOHIDEventSystem private API is needed. The library name remains mechanically accurate.

## What changed

- **smc.c / smc.h** — replaced per-format C decoders (\`SMCGetTemperature\`, \`SMCGetFanSpeed\`) with a single \`SMCRead\` that returns raw bytes + the 4-byte SMC type code. All format decoding moved out of cgo and into Go, so adding new types is a Go change.

- **smc.go**
  - New \`decode()\` handles \`sp78\`, \`fpe2\`, \`flt\`, \`ui8\`, \`ui16\`, \`ui32\`.
  - \`ReadTemperature()\` tries \`TC0P\` first, then \`Tp01\`…\`Tp16\`, returning the hottest sensor found — i.e. the hottest core cluster on Apple Silicon, the CPU proximity sensor on Intel.
  - New \`ReadTemperatures() map[string]float64\` returns the full per-cluster map for callers that want detail (per-core monitoring, sensor naming, etc.).
  - \`ReadFanSpeeds()\` iterates \`F0Ac\`…\`F17Ac\` through the unified decoder, so Apple Silicon's \`flt\` format works.

- **README.md** — Apple Silicon section with the key/format table and the fanless-Mac caveat.

## Architecture mapping

| Reading        | Intel                 | Apple Silicon            |
|----------------|-----------------------|--------------------------|
| CPU temperature | \`TC0P\` (sp78)        | \`Tp01\`…\`Tp16\` (flt)  |
| Fan speed       | \`F0Ac\`…\`F17Ac\` (fpe2) | \`F0Ac\`…\`F17Ac\` (flt) |

Fanless Macs (M1/M2 MacBook Air, Mac mini) have no \`F*Ac\` keys; \`ReadFanSpeeds()\` returns an empty slice there.

## Test plan

- [x] \`go build .\` clean
- [x] Existing \`TestCPU\` / \`TestFans\` / \`TestOpen\` pass on M2 Max (16-inch MBP)
- [x] Live probe shows plausible values: hottest p-core 85.91 °C under load, fans 1587/1715 RPM (well within M2 Max range 1350–5349)
- [ ] Not retested on an Intel Mac. Intel path uses the same SMCRead helper and a separately-tested decoder; \`TC0P\` (sp78) and \`F*Ac\` (fpe2) decoding logic is mechanically unchanged from the previous PR, just relocated from C to Go.